### PR TITLE
add capability to parse config file

### DIFF
--- a/cmd/do/do.go
+++ b/cmd/do/do.go
@@ -1,20 +1,70 @@
 package do
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/urfave/cli/v2"
 )
 
-func runCommand(cmd string, args ...string) ([]byte, error) {
-	out, err := exec.Command(cmd, args...).Output()
+func showListing(config *justV1) {
 
+	// handle no commands listed in the config file
+	if len(config.Commands) <= 0 {
+		fmt.Println("No commands found in config file")
+		return
+	}
+
+	// Format the listing in tabular form
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(w, "Available commands are:")
+	for alias, cmd := range config.Commands {
+		fmt.Fprintln(w, "  "+alias+"\t"+cmd+"\t")
+	}
+	fmt.Fprintln(w)
+
+	// flush the listing to output
+	w.Flush()
+}
+
+func runCommand(cmd string, args ...string) ([]byte, error) {
+
+	// execute the command and capture its stdout and stderr streams
+	out, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		return nil, err
+		return out, err
 	}
 
 	return out, nil
+}
+
+func handleCommand(config *justV1, arg string) error {
+
+	// check if the command is present in the config file
+	entry, ok := config.Commands[arg]
+	if !ok {
+		return errors.New("command `" + arg + "` not found in the config file")
+	}
+
+	// output the command we are running
+	fmt.Println("just @" + entry)
+
+	// execute the command; ignore any additional arguments supplied
+	command := strings.Split(entry, " ")
+	out, err := runCommand(command[0], command[1:]...)
+
+	// print the output from the command run
+	fmt.Println(string(out))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Cmd A sub-command that prints a greeting
@@ -23,14 +73,27 @@ func Cmd() *cli.Command {
 		Name:  "do",
 		Usage: "Runs a command",
 		Action: func(c *cli.Context) error {
-			out, err := runCommand(c.Args().First(), c.Args().Tail()...)
 
+			config, err := parseConfig()
 			if err != nil {
 				return err
 			}
 
-			fmt.Println(string(out))
-			return nil
+			arg := c.Args().First()
+			switch arg {
+			// TODO: use a flag
+			case "list":
+				showListing(&config)
+
+				return nil
+			default:
+				err := handleCommand(&config, arg)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}
 		},
 	}
 }

--- a/cmd/do/justfile.go
+++ b/cmd/do/justfile.go
@@ -1,0 +1,92 @@
+package do
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+)
+
+var configFileName = "just.json"
+
+type versioner struct {
+	Version string `json:"version"`
+}
+
+type justV1 struct {
+	Version  string            `json:"version"`
+	Commands map[string]string `json:"commands"`
+}
+
+func readFile() ([]byte, error) {
+	config, err := ioutil.ReadFile(configFileName)
+	if err != nil {
+		return nil, errors.New("config file not found")
+	}
+
+	return config, nil
+}
+
+func parseJSON(data []byte, container interface{}) error {
+	err := json.Unmarshal(data, container)
+	if err != nil {
+		return errors.New("bad config file format: " + err.Error())
+	}
+
+	return nil
+}
+
+func parseConfigVersion() (string, error) {
+
+	json, err := readFile()
+	if err != nil {
+		return "", err
+	}
+
+	v := versioner{}
+	err = parseJSON(json, &v)
+	if err != nil {
+		return "", err
+	}
+
+	if v.Version == "" {
+		return "", errors.New("config file is missing version")
+	}
+
+	return v.Version, nil
+}
+
+func parseConfigV1() (justV1, error) {
+	json, err := readFile()
+	if err != nil {
+		return justV1{}, err
+	}
+
+	config := justV1{}
+	err = parseJSON(json, &config)
+	if err != nil {
+		return justV1{}, nil
+	}
+
+	return config, nil
+}
+
+// TODO - need a way to return generic versions, not just justV1
+func parseConfig() (justV1, error) {
+
+	version, err := parseConfigVersion()
+	if err != nil {
+		return justV1{}, err
+	}
+
+	// we only allow the versions we know
+	switch version {
+	case "1":
+		config, err := parseConfigV1()
+		if err != nil {
+			return justV1{}, nil
+		}
+		return config, nil
+	default:
+		return justV1{}, errors.New("unknown version: " + version)
+	}
+}

--- a/just.json
+++ b/just.json
@@ -1,0 +1,10 @@
+{
+    "version": "1",
+    "commands": {
+        "build": "yarn build",
+        "build:assets": "docker build -t docker-image:local .",
+        "test": "mvn test",
+        "deploy": "kubectl apply -f k8s/deployment.yaml",
+        "done": "echo done"
+    }
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,10 @@ import (
 )
 
 func main() {
+
+	// Disable timestamps in log messages
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	app := &cli.App{
 		Name:  "just",
 		Usage: "A command runner that runs commands defined in a config file (Justfile by default)",


### PR DESCRIPTION
Adds capability to parse just.json file and extract commands from it.

Currently supports version 1 of the config file with below structure
```json
{
  "version": "1",
  "commands": {
    "alias": "command to run"
  }
}
```